### PR TITLE
Support hightlighting examples

### DIFF
--- a/assets/data/word-lesson-en.yaml
+++ b/assets/data/word-lesson-en.yaml
@@ -46,7 +46,7 @@ lessons:
         gender: female
         examples:
           -
-            arabic: تِلۡكَ أُمَّةٞ قَدۡ خَلَتۡۖ
+            arabic: تِلْكَ أُمَّةٞ قَدۡ خَلَتۡۖ
             meaning: That was a nation that has passed on;
       -
         arabic: هَٰٓؤُلَآء
@@ -102,7 +102,7 @@ lessons:
         plurality: p
         examples:
           -
-            arabic: تِلۡكَ أَمَانِيُّهُمۡۗ
+            arabic: تِلْكَ أَمَانِيُّهُمۡۗ
             meaning: Those are their wishes.
       -
         arabic: نَعَمۡ

--- a/lib/screens/word/word_details.dart
+++ b/lib/screens/word/word_details.dart
@@ -3,8 +3,11 @@ import 'package:learnquran/dto/example.dart';
 import 'package:learnquran/dto/word.dart';
 import 'package:learnquran/theme/theme_helper.dart';
 import 'package:learnquran/widgets/quick_font_selector.dart';
+import 'package:learnquran/widgets/text/arabic_highlighted_text.dart';
 import 'package:learnquran/widgets/text/arabic_text.dart';
 import 'package:learnquran/widgets/word/word_icon.dart';
+import 'package:dartarabic/dartarabic.dart';
+import 'package:highlight_text/highlight_text.dart';
 
 class WordDetails extends StatelessWidget {
   final Word word;
@@ -70,7 +73,8 @@ class WordDetails extends StatelessWidget {
             padding: const EdgeInsets.all(40),
             child: Column(
               children: [
-                ExamplesWidget(examples: word.examples),
+                ExamplesWidget(
+                    originalWord: word.arabic, examples: word.examples),
               ],
             ),
           ),
@@ -82,8 +86,9 @@ class WordDetails extends StatelessWidget {
 
 class ExamplesWidget extends StatelessWidget {
   final List<Example>? examples;
+  final String originalWord;
 
-  const ExamplesWidget({super.key, this.examples});
+  const ExamplesWidget({super.key, required this.originalWord, this.examples});
 
   @override
   Widget build(BuildContext context) {
@@ -96,7 +101,8 @@ class ExamplesWidget extends StatelessWidget {
                   children: [
                     Padding(
                       padding: const EdgeInsets.only(bottom: 10),
-                      child: ArabicText(
+                      child: ArabicHighlightedText(
+                        originalWord,
                         example.arabic,
                         textAlign: TextAlign.center,
                         fontSize: 32,

--- a/lib/widgets/text/arabic_highlighted_text.dart
+++ b/lib/widgets/text/arabic_highlighted_text.dart
@@ -1,0 +1,52 @@
+import 'package:dartarabic/dartarabic.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:learnquran/cubit/arabic_font_cubit.dart';
+import 'package:learnquran/dto/font_family.dart';
+
+class ArabicHighlightedText extends StatelessWidget {
+  final String pattern;
+  final String sentence;
+  final TextAlign? textAlign;
+  final double? fontSize;
+
+  const ArabicHighlightedText(this.pattern, this.sentence,
+      {super.key, this.textAlign, this.fontSize = 32});
+
+  @override
+  Widget build(BuildContext context) {
+    var words = sentence.split(RegExp(' '));
+
+    return BlocBuilder<ArabicFontCubit, FontFamilyOptions>(
+      builder: (context, selectedFontFamilyOption) {
+        return RichText(
+          text: TextSpan(
+            children: words.map((word) {
+              var patternWODiacritics =
+                  DartArabic.stripDiacritics(pattern).normalizeLetters();
+              var wordWODiacritics =
+                  DartArabic.stripDiacritics(word).normalizeLetters();
+
+              var isEqual = patternWODiacritics == wordWODiacritics;
+              return TextSpan(
+                text: '$word ',
+                style: isEqual
+                    ? TextStyle(
+                            fontFamily: fontMap[selectedFontFamilyOption],
+                            fontSize: fontSize,
+                            letterSpacing: 0)
+                        .merge(const TextStyle(
+                            fontWeight: FontWeight.bold, color: Colors.red))
+                    : TextStyle(
+                            fontFamily: fontMap[selectedFontFamilyOption],
+                            fontSize: fontSize,
+                            letterSpacing: 0)
+                        .merge(const TextStyle(color: Colors.black)),
+              );
+            }).toList(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.4"
+  dartarabic:
+    dependency: "direct main"
+    description:
+      name: dartarabic
+      sha256: "203da945e11da7a51f5d65bd67dd098c06ba0ffeb8c95360bf5e1e2ae335579f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -341,6 +349,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  highlight_text:
+    dependency: "direct main"
+    description:
+      name: highlight_text
+      sha256: "74806039a02e65e5aef9bb27c2df42b8694700c389ec75b733eb2ac53a84c606"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.7.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -706,6 +722,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  string_validator:
+    dependency: transitive
+    description:
+      name: string_validator
+      sha256: "50dd8ecf91db6a732f4a851eeae81ee12406eedc62d0da72f2d91a04a2d10dd8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   sqflite: ^2.3.0
   path: ^1.8.3
   logging: ^1.2.0
+  dartarabic: ^0.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
https://github.com/ashrafuzzaman/learn-quran/issues/2

<img width="412" alt="image" src="https://github.com/ashrafuzzaman/learn-quran/assets/47943980/5a0f7ce3-dd55-4999-92ef-ee469aad84f4">

<img width="406" alt="image" src="https://github.com/ashrafuzzaman/learn-quran/assets/47943980/eb577975-1891-408c-b4ff-89811abe50e0">

Still have some issues like ما .. أِلاَّ when the pattern is complex.
In this pr, only 1 word is supported.

Also, we need to fix the dataset, sometimes the original word has nuktah, but the example does not have nuktah.
for example بَلى  is the original word, in it the ى does not have any nuktah, but the example it has nuktah, like this بَلَي

