### PR TITLE
Move flip_card from devDependencies to dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -290,7 +290,7 @@ packages:
     source: hosted
     version: "1.4.0"
   flip_card:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: flip_card
       sha256: "5d4aa58f3983cced0782f4ce45826b7eea36e8e464964d9209dcbc7a87b2292f"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   csv: ^5.1.1
   dartarabic: ^0.1.2
   percent_indicator: ^4.0.1
+  flip_card: ^0.7.0
 
 dev_dependencies:
   flutter_test:
@@ -60,7 +61,6 @@ dev_dependencies:
   flutter_lints: ^3.0.1
   build_runner: ^2.4.7
   custom_lint: ^0.5.7
-  flip_card: ^0.7.0
   flutter_launcher_icons: ^0.13.1
 
 flutter_launcher_icons:


### PR DESCRIPTION
We are using flip_card in one of our public files under 'lib' folder. Thus we need to have it as a main dependency, not a dev dependency otherwise we will encounter issues while building our app for production.